### PR TITLE
add Edogawa-ku version

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,12 @@
 # coding: utf-8
 import datetime
 
-from src.controller import koutou
+# from src.controller import koutou
+from src.controller import edogawa
 
 def main():
-    koutou.main(datetime.date.today() + datetime.timedelta(days=1))
+    # koutou.main(datetime.date.today() + datetime.timedelta(days=1))
+    edogawa.main(datetime.date.today() + datetime.timedelta(days=1))
 
 if __name__ == '__main__':
     main()

--- a/src/controller/edogawa.py
+++ b/src/controller/edogawa.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+import time
+
+from src.models import scraper, reservation
+
+def main(date):
+    start = time.time()
+    reservation_model = reservation.EdogawaReservationModel()
+    scraper_model = scraper.EdogawaScraperModel(date, reservation_model)
+    scraper_model.prepare_for_scraping()
+    scraper_model.scraping()
+    scraper_model.clear()
+    reservation_model.save()
+    end = time.time()
+    print(f'it took {end - start} seconds.')

--- a/src/models/reservation.py
+++ b/src/models/reservation.py
@@ -3,6 +3,7 @@ import datetime
 import os
 import pandas as pd
 import pathlib
+import re
 
 class CsvModel():
     """
@@ -75,3 +76,42 @@ class ReservationModel(CsvModel):
             ]
         )
         df.to_csv(self.csv_file)
+
+
+class EdogawaReservationModel(ReservationModel):
+    """
+    reservation model for edogawa-ku
+    written by 藪智明 2019-11-09
+    """
+    def to_dict_rows(self, rows):
+        res = []
+        header_row = rows[0] # [開始年月日, 日にち, 曜日]
+        now = datetime.datetime.today()
+        year = re.findall('\d{4}[/\.年]', header_row[0])[0].strip("年")
+        month = re.findall('\d{2}[/\.月]', header_row[0])[0].strip("月")
+        for i in range(1, len(rows)):
+            target_institution = rows[i]
+            [building, institution] = target_institution[0]
+            print(f'start appending data for {building} {institution}')
+            for j in range(1, len(target_institution)):
+                target_arr = target_institution[j]
+                reservation_division = target_arr[0]
+                for k in range(1, len(target_arr)):
+                    date = header_row[1][k-1]
+                    day_of_the_week = header_row[2][k-1]
+                    # [date, day_of_the_week] = header_row[j].replace('/','-').replace(')','').split('(')
+                    res.append({
+                        self.BUILDING: building,
+                        self.INSTITUTION: institution,
+                        self.DATE: f'{year}-{month}-{date}',
+                        self.DAY_OF_THE_WEEK: day_of_the_week,
+                        self.RESERVATION_STATUS: target_arr[k],
+                        self.RESERVATION_DIVISION: reservation_division,
+                        self.CREATE_DATETIME: now,
+                        self.UPDATE_DATETIME: now,
+                    })
+        return res
+
+    def append(self, rows):
+        new_data = self.to_dict_rows(rows)
+        self.data.extend(new_data)

--- a/src/models/scraper.py
+++ b/src/models/scraper.py
@@ -5,6 +5,8 @@ from selenium.common.exceptions import TimeoutException, NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
+import chromedriver_binary
+import re
 
 class ScraperModel():
     """
@@ -12,9 +14,10 @@ class ScraperModel():
     """
     def __init__(self, root_url):
         self.root_url = root_url
+        PATH = "/mnt/d/MSAT/chromedriver/chromedriver.exe"
         options = webdriver.ChromeOptions()
         options.add_argument('--headless')
-        self.driver = webdriver.Chrome(options=options)
+        self.driver = webdriver.Chrome(executable_path=PATH)
 
 class KoutouScraperModel(ScraperModel):
     """
@@ -134,5 +137,133 @@ class KoutouScraperModel(ScraperModel):
                 raise e
             self.exec_next_page_script(self.TO_NEXT_INSTITUTE_SCRIPT)
         
+    def clear(self):
+        self.driver.quit()
+
+
+
+
+class EdogawaScraperModel(ScraperModel):
+    """
+    scraper for edogawa-ku
+    written by 藪智明 2019-11-09
+    """
+    ROOT_URL = 'https://www.edogawa-yoyaku.jp/edo-user/'
+
+    SEARCH_VACANT_SCRIPT = "return fcSubmit(FRM_RSGK001,'INIT','rsv.bean.RSGK301BusinessInit','RSGK301');"
+    TO_NEXT_PAGE_SCRIPT = "return fcSubmit_Yoyaku( FRM_RSGK301, 'NEXT', 'rsv.bean.RSGK301BusinessMovePage', 'RSGK301', false, '');"
+    SEARCH_INSTRUMENTAL_LOUD_SCRIPT = "return fcSubmit_Yoyaku( FRM_RSGK301, 'LINK_CLICK', 'rsv.bean.RSGK303BusinessInit', 'RSGK301', false, '0038');"
+    SELECT_FIRST_INSTITUTE_SCRIPT = "return fcSubmit_Yoyaku( FRM_RSGK303, 'LINK_CLICK', 'rsv.bean.RSGK304BusinessInit', 'RSGK303', false, '140');"
+    SELECT_ALL_ROOM_SCRIPT = "return fcSubmit_Yoyaku( FRM_RSGK304, 'LINK_CLICK', 'rsv.bean.RSGK305BusinessInit', 'RSGK304', false, '');"
+    CHANGE_DATE_SCRIPT = "return fcSubmit_Yoyaku( FRM_RSGK305, 'SEARCH_POINT_RSGK306', 'rsv.bean.RSGK306BusinessInit', 'RSGK305', false, '{}');"
+    SHOW_WEEK_VIEW_SCRIPT = "return fcSubmit(FRM_RSGK306,'AKIJOUKYOU_WEEK','rsv.bean.RSGK307BusinessFromRSGK306','RSGK306');"
+    TO_NEXT_INSTITUTE_SCRIPT = "return fcSubmit(FRM_RSGK307,'SEARCH_NEXT1S','rsv.bean.RSGK307BusinessMoveShisetsu','RSGK307');"
+
+    TITLE_XPATH = '//*[@id="{}"]/span' # 施設によってIDが違うので正規表現で指定
+    DATE_XPATH = '//*[@id="FRM_RSGK307"]/div[3]/div/div/table[1]/tbody/tr[1]/td[2]/strong'
+    DAYS_XPATH = '//*[@id="tbl_time3"]/tbody'
+    TABLE_XPATH = '//*[@id="tbl_time2"]/tbody'
+    NEXT_BUTTON_XPATH = '//*[@id="disp"]/center/table[3]/tbody[1]/tr/td/table/tbody/tr/td[3]/a'
+
+    def __init__(self, start_date, reservation_model):
+        super().__init__(self.ROOT_URL)
+        self.start_date = start_date
+        self.reservation_model = reservation_model
+    
+    def exec_next_page_script(self, script):
+        try:
+            WebDriverWait(self.driver, 30).until(EC.presence_of_all_elements_located)
+            time.sleep(5)
+            self.driver.execute_script(script)
+        except TimeoutException as e:
+            print(f'failed to execute script due to timeout. script={script}')
+            raise e
+        except Exception as e:
+            print(f'failed to execute script: {script}')
+            raise e
+
+    def to_rows(self, table):
+        res = []
+        inst_and_arr = [] # [時間帯＆予約状況]の配列
+        building_inst = [] # [building, institution]
+        pattern1 = re.compile("\d{4}-\d{4}") # 正規表現チェック用1 (例: 0900-0930)
+        pattern2 = re.compile("\d{2,4}人|-") # 正規表現チェック用2 (例: 130人)
+        
+        for index, row in enumerate(table.find_elements_by_css_selector('tr')):
+            arr = [] # 1行ずつ読み込む用の配列
+            for i, item in enumerate(row.find_elements_by_tag_name('td')):
+                if i == 0 and not pattern1.fullmatch(item.text): # 施設名と部屋名が来た場合
+
+                    if len(building_inst) == 2: #2回目以降なら
+                        #前回のループで得た [building, institution] を [時間帯＆予約状況]の配列の先頭に追加
+                        inst_and_arr.insert(0,building_inst)
+                        res.append(inst_and_arr)
+                        inst_and_arr = [] # [時間帯＆予約状況]の配列を初期化
+                    
+                    # 以下, 今回のループの処理
+                    building_inst = item.text.split("\n") # [building, institution]
+                elif i == 1 and pattern2.match(item.text): # 人数が場合は無視
+                    continue
+                elif item.text == "": # 何もない場合はとりあえず"VACANT"を入れている
+                    arr.append(item.text.replace("","VACANT"))
+                else:
+                    arr.append(item.text)
+            inst_and_arr.append(arr) # [時間帯＆予約状況]の配列に1行ずつ追加
+        inst_and_arr.insert(0,building_inst) # [building, institution] を先頭に追加
+        res.append(inst_and_arr)
+        return res
+
+
+    def prepare_for_scraping(self):
+        self.driver.get(self.root_url)
+        self.exec_next_page_script(self.SEARCH_VACANT_SCRIPT) # 空状況照会・予約（利用目的から選択）ボタン
+        self.exec_next_page_script(self.TO_NEXT_PAGE_SCRIPT) # 次のページボタン
+        self.exec_next_page_script(self.SEARCH_INSTRUMENTAL_LOUD_SCRIPT) # 器楽（音量大）ボタン
+        self.exec_next_page_script(self.SELECT_FIRST_INSTITUTE_SCRIPT) # 松江区民プラザ（最初の施設）のボタン
+        self.exec_next_page_script(self.SELECT_ALL_ROOM_SCRIPT) # 利用可能な室場分類全てボタン
+
+        # 日付設定
+        self.exec_next_page_script(
+            self.CHANGE_DATE_SCRIPT.format(self.start_date.day) # 本日の日付を入力する　＜＜＜本日の日付がdisabledだったらどうするかは後で＞＞＞
+        )
+
+        self.exec_next_page_script(self.SHOW_WEEK_VIEW_SCRIPT) # 週別表示ボタン
+    
+    def scraping(self):
+        NUMBER_OF_PAGES = 17
+
+        # データ取得 ページ数は17
+        for i in range(NUMBER_OF_PAGES):
+            # scInlineというIDのテーブルが読み込まれるまでは待機
+            WebDriverWait(self.driver, 30).until(EC.presence_of_element_located((By.ID, 'scInline')))
+
+            # IDを検索
+            institute_id = re.findall("RSGK307_\d{4}", self.driver.page_source)
+
+            for j in institute_id:
+                rows = []
+                # 建物名・施設名はテーブルデータに含まれる          
+
+                # 日付・曜日取得 ＜＜＜月をまたぐ場合の処理はまだ＞＞＞
+                start_date = self.driver.find_element_by_xpath(self.DATE_XPATH.format())
+                days = self.driver.find_element_by_xpath(self.DAYS_XPATH)
+
+                [damp, temp_day_of_the_week, temp_date] = re.split("時間|\n", days.text)
+                day_of_the_week = temp_day_of_the_week.split()
+                date = temp_date.split()
+                res = [start_date.text, date, day_of_the_week]
+
+                # テーブルデータ取得
+                table = self.driver.find_element_by_xpath(self.TABLE_XPATH)
+                rows = self.to_rows(table)
+                rows.insert(0,res) # 先頭に日付等のデータを挿入
+
+            # データ保存
+            self.reservation_model.append(rows)
+
+            # 次の施設へ
+            self.exec_next_page_script(self.TO_NEXT_INSTITUTE_SCRIPT)
+
+ 
     def clear(self):
         self.driver.quit()


### PR DESCRIPTION
### **scraper.pyにEdogawaScraperModelを追加**
- 江戸川区の施設予約システムは空き状況の表示が画像ではなく文字での表示だったので、取得した文字列をそのままcsvに出力するようにした（空きの場合は""が取得されるので、今はとりあえず"VACANT"に置き換えている）
-  1つの施設につき1つのページが割り当てており、施設内に部屋が複数ある場合は1つのページ内にまとめて表示される
- そのため、施設名と部屋名は空き状況と同時に取得し、rowsに入れるようにした
- そのためにto_rows()が最も変更されている　reservation側にはrowsのみを渡すようにしている
- rowsの構造
    [[開始年月日, [日付], [曜日]], 
     [[施設名, 部屋名], ["0900-0930", "予約済",  ...], ["0930-1000", "予約済",  ...],  ... ["2030-2100", ...]],
     [[施設名, 部屋名], ["0900-0930", "VACANT",  ...], ["0930-1000", "VACANT",  ...],  ... ["2030-2100", ...]],
      ...]]
- scraper.pyの17行目周辺のwebdriverに関する変更は、Windowsでやる上で必要だったものなので気にしないでください（適宜書き換えをお願いします）

### **reservation.pyにEdogawaReservationModelを追加**
- 上記の変更に伴ってreservationも変更
- ReservationModelを継承することでEdogawaReservatonModelを作成
- to_dict_rows()を主に変更した
- また、buildingとinstitutionをrowsの中に含ませて渡しているのでappend()でbuildingとinstitutionが見れなくなったことを受け、標準出力の場所をto_dict_rows()の中に変更

### **edogawa.pyを作成**
- koutou.pyとほぼ同じ

あとは正規表現での検索を割と使ってます